### PR TITLE
환경변수 리팩토링과 추가 적용

### DIFF
--- a/metaland/settings.py
+++ b/metaland/settings.py
@@ -21,10 +21,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("metaland_SECRET_KEY")
+SECRET_KEY = os.environ.get("MTL_PLAZA_SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("metaland_DEBUG")
-ALLOWED_HOSTS = ["*"]
+DEBUG = os.environ.get("MTL_PLAZA_DEBUG", "false").lower() != "false"
+ALLOWED_HOSTS = list(os.environ.get("MTL_PLAZA_ALLOWED_HOSTS", "*").split(","))
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
@@ -81,11 +81,11 @@ WSGI_APPLICATION = "metaland.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        "NAME": "metaland",
-        "USER": "root",
-        "PASSWORD": os.environ.get("Database_Password"),
-        "HOST": "localhost",
-        "PORT": "3306",
+        "NAME": os.environ.get("MTL_PLAZA_DATABASE", "metaland"),
+        "USER": os.environ.get("MTL_PLAZA_DB_USER", "root"),
+        "PASSWORD": os.environ.get("MTL_PLAZA_DB_PASSWORD", None),
+        "HOST": os.environ.get("MTL_PLAZA_DB_HOST", "localhost"),
+        "PORT": os.environ.get("MTL_PLAZA_DB_PORT", 3306),
         "OPTIONS": {"charset": "utf8mb4"},
     }
 }

--- a/metaland/settings.py
+++ b/metaland/settings.py
@@ -81,7 +81,7 @@ WSGI_APPLICATION = "metaland.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        "NAME": os.environ.get("MTL_PLAZA_DATABASE", "metaland"),
+        "NAME": os.environ.get("MTL_PLAZA_DB_NAME", "metaland"),
         "USER": os.environ.get("MTL_PLAZA_DB_USER", "root"),
         "PASSWORD": os.environ.get("MTL_PLAZA_DB_PASSWORD", None),
         "HOST": os.environ.get("MTL_PLAZA_DB_HOST", "localhost"),


### PR DESCRIPTION
## Summary
* 일관성 있는 환경변수 이름을 위해 [환경변수 컨벤션](https://github.com/deu-meta/metaland#2-4-%ED%99%98%EA%B2%BD%EB%B3%80%EC%88%98-%EC%BB%A8%EB%B2%A4%EC%85%98) 규칙대로 리팩토링 하였음
* 또한 몇몇 환경변수화 되어야 하는 값들에 대해 환경변수 추가 적용하였음

## Changes
* `SECRET_KEY`: `metaland_SECRET_KEY` 를 `MTL_PLAZA_SECRET_KEY` 로 변경
* `DEBUG`: `metaland_DEBUG` 를 `MTL_PLAZA_DEBUG` 로 변경, 기본 값으로 `False` 사용
* `ALLOWED_HOSTS`: 무조건 `["*"]` 값을 가지는 대신 `MTL_PLAZA_ALLOWED_HOSTS` 환경변수 사용. (`,` 로 구분) 기본 값으로 `["*"]` 사용.
* `DATABASES.NAME`: 무조건 `"metaland"` 값을 가지는 대신 이 값을 기본 값으로 사용하며 `MTL_PLAZA_DB_NAME` 으로 변경 가능하도록 함
* `DATABASES.USER`: 무조건 `"root"` 값을 가지는 대신 이 값을 기본 값으로 사용하며 `MTL_PLAZA_DB_USER` 으로 변경 가능하도록 함
* `DATABASES.PASSWORD`: `Database_Password` 를 `MTL_PLAZA_DB_PASSWORD` 로 변경. `None` 값을 기본 값으로 가짐
* `DATABASES.HOST`: 무조건 `"localhost"` 값을 가지는 대신 이 값을 기본 값으로 사용하며 `MTL_PLAZA_DB_HOST` 으로 변경 가능하도록 함
* `DATABASES.PORT`: 무조건 `"3306"` 값을 가지는 대신 이 값을 기본 값으로 사용하며 `MTL_PLAZA_DB_PORT` 으로 변경 가능하도록 함

## Related Issue
Close #12 