### PR TITLE
CORS 지원

### DIFF
--- a/metaland/settings.py
+++ b/metaland/settings.py
@@ -26,6 +26,8 @@ SECRET_KEY = os.environ.get("MTL_PLAZA_SECRET_KEY")
 DEBUG = os.environ.get("MTL_PLAZA_DEBUG", "false").lower() != "false"
 ALLOWED_HOSTS = list(os.environ.get("MTL_PLAZA_ALLOWED_HOSTS", "*").split(","))
 
+CORS_ALLOWED_ORIGINS = list(os.environ.get("MTL_PLAZA_CORS_HOSTS", "http://localhost:3000").split(","))
+
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
@@ -37,6 +39,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    # django-cors-headers
+    "corsheaders",
     # DRF Authentication 이용
     "rest_framework",
     "rest_framework.authtoken",
@@ -52,6 +56,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ click==8.0.1
 colorama==0.4.4
 dj-rest-auth==2.2.4
 Django==4.0.3
+django-cors-headers==3.12.0
 django-filter==21.1
 djangorestframework==3.13.1
 djangorestframework-simplejwt==5.1.0


### PR DESCRIPTION
## Summary
* Front-end에서 metaland-plaza API에 접근할 수 있도록 CORS 지원을 추가하였음
* Front-end의 `host` 를 환경변수 `MTL_PLAZA_CORS_HOSTS` 에 추가하여 적용할 수 있음 (예: `http://localhost:3000,http://localhost:3001`)

## Related Issue
Close #21 