### PR TITLE
`.vscode/launch.json` 에서 runserver의 포트를 8001로 설정

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,8 @@
             "request": "launch",
             "program": "${workspaceFolder}\\manage.py",
             "args": [
-                "runserver"
+                "runserver",
+                "0.0.0.0:8001"
             ],
             "django": true,
             "justMyCode": true


### PR DESCRIPTION
## Summary
* `.vscode/launch.json` 을 통해 서버 실행 시 `8001` 번 포트를 사용하도록 변경

## Related Issue
* Close #42