### PR TITLE
`TokenUserField.__init__` 에서 오류가 발생하는 것을 고침

### DIFF
--- a/metaland/models.py
+++ b/metaland/models.py
@@ -50,9 +50,6 @@ class TokenUserField(models.JSONField):
     clean_keys = ["iat", "nbf", "jti", "exp", "type", "fresh"]
     """JWT Payload에서 사용하지 않을 필드들"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
-
     def from_db_value(self, value, expression, connection):
         value = super().from_db_value(value, expression, connection)
         if value is None:


### PR DESCRIPTION
## Summary
* `__init__` 함수를 삭제하여 해결

## Related Issue
* Close #44 