### PR TITLE
`docker-entrypoint.sh` 파일 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,18 @@ FROM python:3.9
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-WORKDIR /metaland-plaza
-COPY requirements.txt .
+# Download wait-for-it.sh
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /
+RUN chmod +x /wait-for-it.sh
 
+WORKDIR /metaland-plaza
+
+COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .
+RUN chmod +x docker-entrypoint.sh
 
 EXPOSE 8000
 
-ENTRYPOINT ["python", "manage.py"]
-
-CMD ["runserver", "0.0.0.0:8000"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# wait until db ready
+/wait-for-it.sh -t 0 $MTL_PLAZA_DB_HOST:$MTL_PLAZA_DB_PORT
+
+if [ -z "$MTL_PLAZA_PORT" ]; then
+    export MTL_PLAZA_PORT=8000
+fi
+
+if [ -z "$MTL_PLAZA_BIND_ADDRESS" ]; then
+    export MTL_PLAZA_BIND_ADDRESS=0.0.0.0
+fi
+
+command_args=$@
+if [ -z "$command_args" ]; then
+    command_args="runserver $MTL_PLAZA_BIND_ADDRESS:$MTL_PLAZA_PORT"
+fi
+
+# if something get wrong, do not run server
+python manage.py migrate --noinput || exit 1
+
+# important! last line should be exec, so the process can receive SIGTERM from docker stop.
+exec python manage.py $command_args


### PR DESCRIPTION
## Summary
* 컨테이너 실행 시 `docker-entrypoint.sh` 를 실행하도록 설정
* Django가 켜지기 전 DB가 사용가능해질때까지 기다리는 역할과,
* migrate를 실행하는 역할을 수행

## Related Issue
* Close #24 